### PR TITLE
Automatically determine remote name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -26,9 +26,11 @@ function activate(context) {
       let lineIndex = editor.selection.active.line + 1;
       let cwd = vscode.workspace.rootPath;
       let config = parseConfig.sync({cwd: cwd});
-      let branch = gitBranch.sync(cwd)
-      if (config['remote \"origin\"']) {
-        let githubRootUrl = githubUrlFromGit(config['remote \"origin\"'].url);
+      let branch = gitBranch.sync(cwd);
+      let remote = config[`branch "${branch}"`].remote || 'origin';
+
+      if (config[`remote "${remote}"`]) {
+        let githubRootUrl = githubUrlFromGit(config[`remote "${remote}"`].url);
         let subdir = editor.document.fileName.substring(cwd.length);
         let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
         url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows


### PR DESCRIPTION
For some projects I'm using multiple git remotes. However the problem with current implementation is that it relies on hardcoded `origin` remote which is not always the case.

In my case it would create wrong links in case if my current branch would upstream to any other remote than the `origin`. This pull request fixes this issue.

I would appreciate if you bump the plugin version after accepting PR, so that the change is visible, thanks!

BTW thanks for great plugin, which saves me writing it for myself, because this is a feature I use a lot in IDEs! 👍 