### PR TITLE
Fixed an exception when the branch doesn't have the upstream.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -27,10 +27,11 @@ function activate(context) {
       let cwd = vscode.workspace.rootPath;
       let config = parseConfig.sync({cwd: cwd});
       let branch = gitBranch.sync(cwd);
-      let remote = config[`branch "${branch}"`].remote || 'origin';
+      let remoteConfig = config[`branch "${branch}"`];
+      let remoteName = remoteConfig && remoteConfig.remote ? remoteConfig.remote : 'origin';
 
-      if (config[`remote "${remote}"`]) {
-        let githubRootUrl = githubUrlFromGit(config[`remote "${remote}"`].url);
+      if (config[`remote "${remoteName}"`]) {
+        let githubRootUrl = githubUrlFromGit(config[`remote "${remoteName}"`].url);
         let subdir = editor.document.fileName.substring(cwd.length);
         let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
         url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows


### PR DESCRIPTION
Hi, thanks for quickly accepting yesterday PR however it had a bug.

If branch does not have any upstream branch assigned, it won't appear in `config` object, thus [line 30](https://github.com/differentmatt/vscode-copy-github-url/blob/1d390c04c14475c1e0077a8037c2917e9b213342/extension.js#L30) will throw an exception due to accessing property of an undefined.

This PR makes accessing this property much safer, and sets remote to the `origin` in case if no upstream is set.