### PR TITLE
Added multiline support (and tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 *.vsix
+.vscode
+yarn.lock

--- a/extension.js
+++ b/extension.js
@@ -2,9 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 let vscode = require('vscode');
-let parseConfig = require('parse-git-config');
-let gitBranch = require('git-branch');
-let githubUrlFromGit = require('github-url-from-git');
+let main = require('./src/main');
 let copyPaste = require("copy-paste");
 
 // This method is called when your extension is activated
@@ -18,25 +16,7 @@ function activate(context) {
 
     // The code you place here will be executed every time your command is executed
     try {
-      let editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        console.error('No open text editor');
-        return;
-      }
-      let lineIndex = editor.selection.active.line + 1;
-      let cwd = vscode.workspace.rootPath;
-      let config = parseConfig.sync({cwd: cwd});
-      let branch = gitBranch.sync(cwd);
-      let remoteConfig = config[`branch "${branch}"`];
-      let remoteName = remoteConfig && remoteConfig.remote ? remoteConfig.remote : 'origin';
-
-      if (config[`remote "${remoteName}"`]) {
-        let githubRootUrl = githubUrlFromGit(config[`remote "${remoteName}"`].url);
-        let subdir = editor.document.fileName.substring(cwd.length);
-        let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
-        url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
-        copyPaste.copy(url);
-      }
+      copyPaste.copy(main.getGithubUrl(vscode));
     }
     catch (e) {
       console.log(e);

--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,11 @@ function activate(context) {
 
     // The code you place here will be executed every time your command is executed
     try {
-      copyPaste.copy(main.getGithubUrl(vscode));
+      var url = main.getGithubUrl(vscode);
+
+      if ( url ) {
+        copyPaste.copy( url );
+      }
     }
     catch (e) {
       console.log(e);

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,38 @@
+"use strict";
+
+let vscode = require('vscode');
+let parseConfig = require('parse-git-config');
+let gitBranch = require('git-branch');
+let githubUrlFromGit = require('github-url-from-git');
+
+module.exports = {
+  /**
+   * Returns a GitHub URL to the currently selected line in VSCode instance.
+   *
+   * @param mixed vscode
+   * @returns String/null Returns an URL or `null` if could not be determined.
+   */
+  getGithubUrl: function( vscode ) {
+    let editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      console.error('No open text editor');
+      return;
+    }
+    let lineIndex = editor.selection.active.line + 1;
+    let cwd = vscode.workspace.rootPath;
+    let config = parseConfig.sync({cwd: cwd});
+    let branch = gitBranch.sync(cwd);
+    let remoteConfig = config[`branch "${branch}"`];
+    let remoteName = remoteConfig && remoteConfig.remote ? remoteConfig.remote : 'origin';
+
+    if (config[`remote "${remoteName}"`]) {
+      let githubRootUrl = githubUrlFromGit(config[`remote "${remoteName}"`].url);
+      let subdir = editor.document.fileName.substring(cwd.length);
+      let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
+      url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
+      return url;
+    } else {
+      return null;
+    }
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -21,13 +21,9 @@ module.exports = {
     let lineIndex = editor.selection.active.line + 1;
     let cwd = vscode.workspace.rootPath;
     let gitInfo = this._getGitInfo( vscode );
-    let remoteName = gitInfo.remote;
-    let branch = gitInfo.branch;
-    let githubRootUrl = gitInfo.githubUrl;
-
-
     let subdir = editor.document.fileName.substring(cwd.length);
-    let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
+
+    let url = `${gitInfo.githubUrl}/blob/${gitInfo.branch}${subdir}#L${lineIndex}`;
     url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
     return url;
   },

--- a/src/main.js
+++ b/src/main.js
@@ -9,30 +9,56 @@ module.exports = {
   /**
    * Returns a GitHub URL to the currently selected line in VSCode instance.
    *
-   * @param mixed vscode
-   * @returns String/null Returns an URL or `null` if could not be determined.
+   * @param {mixed} vscode
+   * @returns {String/null} Returns an URL or `null` if could not be determined.
    */
   getGithubUrl: function( vscode ) {
     let editor = vscode.window.activeTextEditor;
     if (!editor) {
       console.error('No open text editor');
-      return;
+      return null;
     }
     let lineIndex = editor.selection.active.line + 1;
+    let cwd = vscode.workspace.rootPath;
+    let gitInfo = this._getGitInfo( vscode );
+    let remoteName = gitInfo.remote;
+    let branch = gitInfo.branch;
+    let githubRootUrl = gitInfo.githubUrl;
+
+
+    let subdir = editor.document.fileName.substring(cwd.length);
+    let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
+    url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
+    return url;
+  },
+
+  /**
+   * Returns git repo information object for given `vscode` instance.
+   *
+   * @private
+   * @param {mixed} vscode
+   * @returns {Object} return
+   * @returns {String} return.branch Current branch name.
+   * @returns {String} return.remote Currently set upstream, will fallback to 'origin' if none set.
+   * @returns {String} return.url URL to a Git repository.
+   * @returns {String} return.githubUrl URL to a GitHub page for given repository.
+   */
+  _getGitInfo: function( vscode ) {
     let cwd = vscode.workspace.rootPath;
     let config = parseConfig.sync({cwd: cwd});
     let branch = gitBranch.sync(cwd);
     let remoteConfig = config[`branch "${branch}"`];
     let remoteName = remoteConfig && remoteConfig.remote ? remoteConfig.remote : 'origin';
 
-    if (config[`remote "${remoteName}"`]) {
-      let githubRootUrl = githubUrlFromGit(config[`remote "${remoteName}"`].url);
-      let subdir = editor.document.fileName.substring(cwd.length);
-      let url = `${githubRootUrl}/blob/${branch}${subdir}#L${lineIndex}`;
-      url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
-      return url;
-    } else {
-      return null;
+    if ( !config[`remote "${remoteName}"`] ) {
+      throw new Error( `Could not fetch information about "${remoteName}" remote.` );
     }
+
+    return {
+      branch: branch,
+      remote: remoteName,
+      url: config[`remote "${remoteName}"`].url, // An URL to git repository itself.
+      githubUrl: githubUrlFromGit(config[`remote "${remoteName}"`].url) // An URL to the GitHub page for given repository.
+    };
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ module.exports = {
       return null;
     }
 
-    let lineQuery = 'L' + (selection.active.line + 1);
+    let lineQuery = 'L' + (selection.start.line + 1);
 
     if ( !selection.isSingleLine ) {
       // Selection might be spanned across multiple lines.

--- a/src/main.js
+++ b/src/main.js
@@ -14,16 +14,24 @@ module.exports = {
    */
   getGithubUrl: function( vscode ) {
     let editor = vscode.window.activeTextEditor;
+    let selection = editor.selection;
     if (!editor) {
       console.error('No open text editor');
       return null;
     }
-    let lineIndex = editor.selection.active.line + 1;
+
+    let lineQuery = 'L' + (selection.active.line + 1);
+
+    if ( !selection.isSingleLine ) {
+      // Selection might be spanned across multiple lines.
+      lineQuery += ('-L' + (selection.end.line + 1));
+    }
+
     let cwd = vscode.workspace.rootPath;
     let gitInfo = this._getGitInfo( vscode );
     let subdir = editor.document.fileName.substring(cwd.length);
 
-    let url = `${gitInfo.githubUrl}/blob/${gitInfo.branch}${subdir}#L${lineIndex}`;
+    let url = `${gitInfo.githubUrl}/blob/${gitInfo.branch}${subdir}#${lineQuery}`;
     url = url.replace(/\\/g, '/'); // Flip subdir slashes on Windows
     return url;
   },

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -6,19 +6,47 @@
 //
 
 // The module 'assert' provides assertion methods from node
-var assert = require('assert');
+let assert = require('assert');
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-var vscode = require('vscode');
-var myExtension = require('../extension');
+let vscode = require('vscode');
+let myExtension = require('../extension');
+let main = require('../src/main');
 
 // Defines a Mocha test suite to group tests of similar kind together
-suite('Extension Tests', function() {
+suite('main', function() {
+	main._getGitInfo = function( vscode ) {
+		// Stub the method to always have the same results.
+		return {
+			branch:'master',
+			remote:'origin',
+			url:'git@github.com:foo/bar-baz.git',
+			githubUrl:'https://github.com/foo/bar-baz'
+		};
+	}
 
-	// Defines a Mocha unit test
-	test('Something 1', function() {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
+	test('getGithubUrl - windows path', function() {
+		let editorMock = {
+			selection: {
+				active: {
+					line: 4
+				}
+			},
+			document: {
+				fileName: 'F:\\my\\workspace\\foo\\subdir1\\subdir2\\myFileName.txt'
+			}
+		};
+		let vsCodeMock = {
+			workspace: {
+				rootPath: 'F:\\my\\workspace\\foo'
+			},
+			window: {
+				activeTextEditor: editorMock
+			}
+		};
+		let url = main.getGithubUrl( vsCodeMock );
+
+		assert.equal('https://github.com/foo/bar-baz/blob/master/subdir1/subdir2/myFileName.txt#L5', url, 'Invalid URL returned');
 	});
 });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,6 +1,6 @@
 /* global suite, test */
 
-// 
+//
 // Note: This example test is leveraging the Mocha test framework.
 // Please refer to their documentation on https://mochajs.org/ for help.
 //
@@ -14,10 +14,10 @@ var vscode = require('vscode');
 var myExtension = require('../extension');
 
 // Defines a Mocha test suite to group tests of similar kind together
-suite("Extension Tests", function() {
+suite('Extension Tests', function() {
 
 	// Defines a Mocha unit test
-	test("Something 1", function() {
+	test('Something 1', function() {
 		assert.equal(-1, [1, 2, 3].indexOf(5));
 		assert.equal(-1, [1, 2, 3].indexOf(0));
 	});

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -107,4 +107,20 @@ suite('main', function() {
 
 		assert.equal(url, 'https://github.com/foo/bar-baz/blob/master/bar.md#L31-L41', 'Invalid URL returned');
 	});
+
+	test('getGithubUrl - same active.line as end.line', function() {
+		// Tehere might be a case, where selection.active.line will be the same as selection.end.line. It caused a problem at one point.
+		let vsCodeMock = getVsCodeMock( {
+			startLine: 1,
+			endLine: 5,
+			projectDirectory: 'T:\foo',
+			filePath: 'bar.md'
+		} );
+
+		vsCodeMock.window.activeTextEditor.selection.active.line = 5;
+
+		let url = main.getGithubUrl( vsCodeMock );
+
+		assert.equal(url, 'https://github.com/foo/bar-baz/blob/master/bar.md#L2-L6', 'Invalid URL returned');
+	});
 });


### PR DESCRIPTION
I was missing multiline support, so being able to create a link for a selection that goes for more than one line.

Below is a screencast how it how it looks from end user perspective:

![github-copy-multiline](https://cloud.githubusercontent.com/assets/5353898/20990726/95b48f56-bcda-11e6-98f2-abeca6bdc66a.gif)

The thing here is that with this PR I wanted to be sure that it's covered with unit tests, and to make it happen I had to do a major extractions here and there, so we can conveniently load parts of code in unit tests.

But the good news is that testing is now pretty easy!