### PR TITLE
Add setting gitUrl to handle Github Enterprise

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
         "configuration": {
             "title": "Copy github url configuration",
             "properties": {
-				"copyGithubUrl.rootGitFolder": {
-					"type": "string",
-					"description": "Provides the relative path to the folder that contains the .git folder for the current opened workspace"
-				},
-				"copyGithubUrl.gitUrl": {
-					"type": "string",
-					"description": "The github domain. Eg: github.example.com"
-				}
+                "copyGithubUrl.rootGitFolder": {
+                    "type": "string",
+                    "description": "Provides the relative path to the folder that contains the .git folder for the current opened workspace"
+                },
+                "copyGithubUrl.gitUrl": {
+                    "type": "string",
+                    "description": "The github domain. Eg: github.example.com"
+                }
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -54,10 +54,14 @@
         "configuration": {
             "title": "Copy github url configuration",
             "properties": {
-                "rootGitFolder": {
-                    "type": "string",
-                    "description": "Provides the relative path to the folder that contains the .git folder for the current opened workspace"
-                }
+				"copyGithubUrl.rootGitFolder": {
+					"type": "string",
+					"description": "Provides the relative path to the folder that contains the .git folder for the current opened workspace"
+				},
+				"copyGithubUrl.gitUrl": {
+					"type": "string",
+					"description": "The github domain. Eg: github.example.com"
+				}
             }
         }
     },

--- a/src/main.js
+++ b/src/main.js
@@ -53,14 +53,14 @@ module.exports = {
    * @returns {String} [return.hash] A hash for the current repository. This property is available only if `includeHash` was set to `true`.
    */
   _getGitInfo: function (vscode, includeHash) {
-    let cwd = vscode.workspace.rootPath;
-    let config = parseConfig.sync({ cwd: cwd });
+    let cwd = vscode.workspace.rootPath
+    let config = parseConfig.sync({ cwd: cwd })
     
-    const vscodeConfig = vscode.workspace.getConfiguration('copyGithubUrl');
-    const gitUrl = vscodeConfig.get('gitUrl');
+    const vscodeConfig = vscode.workspace.getConfiguration('copyGithubUrl')
+    const gitUrl = vscodeConfig.get('gitUrl')
 
     if (!config) {
-      const rootGitFolder = vscodeConfig.get('rootGitFolder');
+      const rootGitFolder = vscodeConfig.get('rootGitFolder')
 
       if (rootGitFolder) {
         cwd = path.resolve(vscode.workspace.rootPath, rootGitFolder)

--- a/src/main.js
+++ b/src/main.js
@@ -56,9 +56,11 @@ module.exports = {
     let cwd = vscode.workspace.rootPath;
     let config = parseConfig.sync({ cwd: cwd });
     
+    const vscodeConfig = vscode.workspace.getConfiguration('copyGithubUrl');
+    const gitUrl = vscodeConfig.get('gitUrl');
+
     if (!config) {
-      const vscodeConfig = vscode.workspace.getConfiguration('copyGithubUrl');
-      const rootGitFolder = (vscodeConfig || {}).rootGitFolder;
+      const rootGitFolder = vscodeConfig.get('rootGitFolder');
 
       if (rootGitFolder) {
         cwd = path.resolve(vscode.workspace.rootPath, rootGitFolder);
@@ -77,7 +79,7 @@ module.exports = {
       branch: branch,
       remote: remoteName,
       url: config[`remote "${remoteName}"`].url, // An URL to git repository itself.
-      githubUrl: githubUrlFromGit(config[`remote "${remoteName}"`].url), // An URL to the GitHub page for given repository.
+      githubUrl: githubUrlFromGit(config[`remote "${remoteName}"`].url, gitUrl && {extraBaseUrls: [gitUrl]}), // An URL to the GitHub page for given repository.
       // Include hash only on demand as it might be a costy operation.
       hash: includeHash ? gitRevSync.short(cwd) : null,
     };


### PR DESCRIPTION
## Fix settings
A [WorkspaceConfiguration](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration) has getter and setter. Also added a namespace to this extension settings. (Might be breaking change since the previous user configuration won't work.)

## Add gitUrl to handle GHE
Pass the new `gitUrl` to `githubUrlFromGit` as [`extraBaseUrls`](https://github.com/tj/node-github-url-from-git/blob/master/test.js#L74) to handle GHE
