### PR TITLE
Switch to long hash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ module.exports = {
       url: config[`remote "${remoteName}"`].url, // An URL to git repository itself.
       githubUrl: githubUrlFromGit(config[`remote "${remoteName}"`].url, gitUrl && {extraBaseUrls: [gitUrl]}), // An URL to the GitHub page for given repository.
       // Include hash only on demand as it might be a costy operation.
-      hash: includeHash ? gitRevSync.short(cwd) : null
+      hash: includeHash ? gitRevSync.long(cwd) : null
     }
   }
 }

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -67,7 +67,7 @@ suite('main', function () {
       remote: 'origin',
       url: 'git@github.com:foo/bar-baz.git',
       githubUrl: 'https://github.com/foo/bar-baz',
-      hash: '1a1433f',
+      hash: '75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef',
     };
   }
 
@@ -113,7 +113,7 @@ suite('main', function () {
     });
     let url = main.getGithubUrl(vsCodeMock, true);
 
-    assert.equal(url, 'https://github.com/foo/bar-baz/blob/1a1433f/ipsum.md#L1-L2', 'Invalid URL returned');
+    assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/ipsum.md#L1-L2', 'Invalid URL returned');
   });
 
   test('getGithubUrl - same active.line as end.line', function () {


### PR DESCRIPTION
This will make the URL seamlessly render as a code block in the context of GitHub markdown.

Note: I haven't tested this as I'm not sure how you run and test local VS Code extensions 😬 

Resolves https://github.com/differentmatt/vscode-copy-github-url/issues/15