### PR TITLE
Support symbols in the file name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,6 @@ module.exports = {
    *
    * @param {mixed} vscode
    * @param {Boolean} [permalink=false] Should it be permalink? If `true` it will link to current revision hash
-   * @param {string} [platform=process.platform] The platform to determine the path separator. The default value is `process.platform`.
    * rather than branch.
    * @returns {String/null} Returns an URL or `null` if could not be determined.
    */

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ module.exports = {
    *
    * @param {mixed} vscode
    * @param {Boolean} [permalink=false] Should it be permalink? If `true` it will link to current revision hash
+   * @param {string} [pathSeparator] A path separator (Default value is the returned value from path.sep)
    * rather than branch.
    * @returns {String/null} Returns an URL or `null` if could not be determined.
    */

--- a/src/main.js
+++ b/src/main.js
@@ -39,14 +39,8 @@ module.exports = {
 
     const subdir = editor.document.fileName.substring(cwd.length)
 
-    // Determine the path separator by using platform.
-    // Note: The config.platform overrides process.platform for easy to test.
-    let pathSeparator = ''
-    if(config.platform === 'win32' || (!config.platform && process.platform === 'win32')) {
-      pathSeparator = '\\'
-    } else {
-      pathSeparator = '/'
-    }
+    let pathSeparator = config.pathSeparator || path.sep;
+
     // If the file contains symbols, we need to encode by using encodeURI function.
     // Additionally `#` and `?` in the pathname should be replaced with `%23` and `%3F` respectively.
     const subdirEncoded = subdir.split(pathSeparator).map((p) => encodeURI(p).replace('#', '%23').replace('?', '%3F')).join('/')

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -164,7 +164,7 @@ suite('main', function () {
 
     vsCodeMock.window.activeTextEditor.selection.active.line = 5;
 
-    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock);
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L2-L6', 'Invalid URL returned');
   });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -88,7 +88,7 @@ suite('main', function () {
     let vsCodeMock = getVsCodeMock({
       startLine: 4,
     });
-    let url = await main.getGithubUrl(vsCodeMock);
+    let url = await main.getGithubUrl(vsCodeMock, {platform: 'win32'});
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/subdir1/subdir2/myFileName.txt#L5', 'Invalid URL returned');
   });
@@ -99,7 +99,7 @@ suite('main', function () {
       projectDirectory: 'T:\foo',
       filePath: 'bar.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock);
+    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L103', 'Invalid URL returned');
   });
@@ -112,7 +112,7 @@ suite('main', function () {
       projectDirectory: 'T:\foo',
       filePath: 'bar.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock);
+    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L31-L41', 'Invalid URL returned');
   });
@@ -124,7 +124,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock);
+    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -136,7 +136,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { perma: true });
+    let url = await main.getGithubUrl(vsCodeMock, { perma: true, platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -148,7 +148,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { default: true });
+    let url = await main.getGithubUrl(vsCodeMock, { default: true, platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/main/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -164,8 +164,20 @@ suite('main', function () {
 
     vsCodeMock.window.activeTextEditor.selection.active.line = 5;
 
-    let url = await main.getGithubUrl(vsCodeMock);
+    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L2-L6', 'Invalid URL returned');
+  });
+
+  test('getGithubUrl - permalink for a file that contains symbols on macOS', async function () {
+    let vsCodeMock = getVsCodeMock({
+      startLine: 0,
+      endLine: 1,
+      projectDirectory: '/foo',
+      filePath: 'a !"#$%&\'()*+,-.:;<=>?@[\\]^`{|}~.md',
+    });
+    let url = await main.getGithubUrl(vsCodeMock, { perma: true, platform: 'darwin'});
+
+    assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/a%20!%22%23$%25&\'()*+,-.:;%3C=%3E%3F@%5B%5C%5D%5E%60%7B%7C%7D~.md#L1-L2', 'Invalid URL returned');
   });
 });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -88,7 +88,7 @@ suite('main', function () {
     let vsCodeMock = getVsCodeMock({
       startLine: 4,
     });
-    let url = await main.getGithubUrl(vsCodeMock, {platform: 'win32'});
+    let url = await main.getGithubUrl(vsCodeMock, { pathSeparator: '\\' });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/subdir1/subdir2/myFileName.txt#L5', 'Invalid URL returned');
   });
@@ -99,7 +99,7 @@ suite('main', function () {
       projectDirectory: 'T:\foo',
       filePath: 'bar.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock);
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L103', 'Invalid URL returned');
   });
@@ -112,7 +112,7 @@ suite('main', function () {
       projectDirectory: 'T:\foo',
       filePath: 'bar.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock);
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/bar.md#L31-L41', 'Invalid URL returned');
   });
@@ -124,7 +124,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock);
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/test-branch/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -136,7 +136,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { perma: true, platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock, { perma: true });
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -148,7 +148,7 @@ suite('main', function () {
       projectDirectory: 'T:\lorem',
       filePath: 'ipsum.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { default: true, platform: 'win32' });
+    let url = await main.getGithubUrl(vsCodeMock, { default: true});
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/main/ipsum.md#L1-L2', 'Invalid URL returned');
   });
@@ -176,8 +176,20 @@ suite('main', function () {
       projectDirectory: '/foo',
       filePath: 'a !"#$%&\'()*+,-.:;<=>?@[\\]^`{|}~.md',
     });
-    let url = await main.getGithubUrl(vsCodeMock, { perma: true, platform: 'darwin'});
+    let url = await main.getGithubUrl(vsCodeMock, { perma: true, pathSeparator: '/'});
 
     assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/a%20!%22%23$%25&\'()*+,-.:;%3C=%3E%3F@%5B%5C%5D%5E%60%7B%7C%7D~.md#L1-L2', 'Invalid URL returned');
+  });
+
+  test('getGithubUrl - permalink for a file that contains symbols with \\ pathSeparator', async function () {
+    let vsCodeMock = getVsCodeMock({
+      startLine: 0,
+      endLine: 1,
+      projectDirectory: 'T:\foo',
+      filePath: 'a !"#$%&\'()*+,-.:;<=>?@[\\]^`{|}~.md',
+    });
+    let url = await main.getGithubUrl(vsCodeMock, { perma: true, pathSeparator: '\\' });
+
+    assert.equal(url, 'https://github.com/foo/bar-baz/blob/75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef/a%20!%22%23$%25&\'()*+,-.:;%3C=%3E%3F@%5B/%5D%5E%60%7B%7C%7D~.md#L1-L2', 'Invalid URL returned');
   });
 });


### PR DESCRIPTION
This extension helps me a lot. Thank you so much!

## Overview

This PR is for supporting symbols in a file name. I researched the rules for generating GitHub permalink for symbols in [my repository](https://github.com/negibokken/github-url-test).

We can support symbols in a file name by using [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) and replacing `#` and `?` with `%23` and `%3F` respectively in GitHub.

## Note

For easy testing, the `platform` is introduced in `config` because the path separator is different between platforms.

I consider using [`path.sep`](https://nodejs.org/api/path.html#pathsep), but `path.sep` always returns `/` because my machine is macOS. So for making the platform injectable, the platform config is needed.