### PR TITLE
Add domainOverride setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,14 @@
                     "type": "string",
                     "description": "Default branch name to use if it cannot be determined dynamically"
                 },
+                "copyGithubUrl.domainOverride": {
+                    "type": "string",
+                    "description": "GitHub domain override, for scenarios like enterprise instances or SSH aliases. E.g. github.example.com"
+                },
                 "copyGithubUrl.gitUrl": {
                     "type": "string",
-                    "description": "The github domain. Eg: github.example.com"
+                    "description": "Deprecated: Use domainOverride instead. GitHub domain override, for scenarios like enterprise instances or SSH aliases.",
+                    "deprecationMessage": "This setting is deprecated. Please use copyGithubUrl.domainOverride instead."
                 },
                 "copyGithubUrl.rootGitFolder": {
                     "type": "string",


### PR DESCRIPTION
Prioritize configuration setting domainOverride over git remote info when constructing URLs. Deprecate configuration setting gitUrl and use as a fallback for domainOverride.

Prioritize configuration setting defaultBranchFallback over other lookups.

Fixes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option for a GitHub domain override, enabling customization for enterprise or SSH scenarios.
  - Updated the logic for default branch detection so that user-specified fallback settings are prioritized.
  - Ensured backward compatibility by maintaining support for legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->